### PR TITLE
MR 110 토큰 인증 업데이트

### DIFF
--- a/src/main/java/mathrone/backend/config/SwaggerConfig.java
+++ b/src/main/java/mathrone/backend/config/SwaggerConfig.java
@@ -1,19 +1,12 @@
 package mathrone.backend.config;
 
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.info.License;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import org.springframework.stereotype.Component;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.ApiKey;
 import springfox.documentation.service.AuthorizationScope;
 import springfox.documentation.service.SecurityReference;
@@ -27,6 +20,8 @@ import java.util.List;
 @Configuration
 @Component
 public class SwaggerConfig {
+
+    private static final String APIKEY_NAME = "Access Token";
 
     @Bean
     public Docket api2() {
@@ -54,11 +49,11 @@ public class SwaggerConfig {
         AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
         AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
         authorizationScopes[0] = authorizationScope;
-        return Arrays.asList(new SecurityReference("Authorization", authorizationScopes));
+        return Arrays.asList(new SecurityReference(APIKEY_NAME, authorizationScopes));
     }
 
     private ApiKey apiKey() {
-        return new ApiKey("Authorization", "Authorization", "header");
+        return new ApiKey(APIKEY_NAME, "Authorization", "header");
     }
 
 }

--- a/src/main/java/mathrone/backend/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/mathrone/backend/config/jwt/JwtAuthenticationFilter.java
@@ -8,7 +8,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import mathrone.backend.repository.tokenRepository.LogoutAccessTokenRedisRepository;
 import mathrone.backend.util.TokenProviderUtil;
-import org.springframework.lang.NonNullApi;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;

--- a/src/main/java/mathrone/backend/domain/enums/UserResType.java
+++ b/src/main/java/mathrone/backend/domain/enums/UserResType.java
@@ -1,0 +1,18 @@
+package mathrone.backend.domain.enums;
+
+
+public enum UserResType {
+
+    MATHRONE("MATHRONE"),
+    GOOGLE("GOOGLE");
+    
+    private final String typeName;
+
+    UserResType(String name) {
+        this.typeName = name;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+}

--- a/src/main/java/mathrone/backend/service/AuthService.java
+++ b/src/main/java/mathrone/backend/service/AuthService.java
@@ -1,5 +1,8 @@
 package mathrone.backend.service;
 
+import static mathrone.backend.domain.enums.UserResType.GOOGLE;
+import static mathrone.backend.domain.enums.UserResType.MATHRONE;
+
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import mathrone.backend.controller.dto.*;
@@ -38,11 +41,11 @@ public class AuthService {
     public UserResponseDto signup(UserSignUpDto userSignUpDto) {
         // && type이 MATHRONE인 경우도 같이 검사 -> 같은 id로 여러 sns시스템을 이용할 수 있기 때문
         if (userinfoRepository.existsUserInfoByAccountIdAndResType(userSignUpDto.getAccountId(),
-            "MATHRONE")) {
+            MATHRONE.getTypeName())) {
             throw new RuntimeException("이미 가입된 유저입니다.");
         }
         UserInfo newUser = userSignUpDto.toUser(passwordEncoder,
-            "MATHRONE"); //MATHRONE user로 가입시켜주기
+            MATHRONE.getTypeName()); //MATHRONE user로 가입시켜주기
         return UserResponseDto.of(userinfoRepository.save(newUser));
     }
 
@@ -51,7 +54,7 @@ public class AuthService {
 
         UserSignUpDto userSignUpDto = new UserSignUpDto(googleIDToken.getBody().getEmail(),
             "googleLogin", googleIDToken.getBody().getEmail()); //id와 email을 email로 채워서 만들기
-        UserInfo newUser = userSignUpDto.toUser(passwordEncoder, "GOOGLE");
+        UserInfo newUser = userSignUpDto.toUser(passwordEncoder, GOOGLE.getTypeName());
 
         return UserResponseDto.of(userinfoRepository.save(newUser));
     }
@@ -61,7 +64,7 @@ public class AuthService {
 
         //가입이 안되어 있는 경우
         if (!userinfoRepository.existsByEmailAndResType(googleIDToken.getBody().getEmail(),
-            "GOOGLE")) {
+            GOOGLE.getTypeName())) {
             signupWithGoogle(googleIDToken);
         }
 
@@ -98,7 +101,7 @@ public class AuthService {
     @Transactional
     public void deleteUser(String accountId, String resType) {
         // resType에 대한 구분을 enum class로 다루는 방안에 대해 토의하기
-        if (resType.equals("MATHRONE")) {
+        if (resType.equals(MATHRONE.getTypeName())) {
             // accountId가 존재하지 않는 경우에 대한 예외처리 작성하기
             userinfoRepository.deleteByAccountIdAndResType(accountId, resType);
         }

--- a/src/main/java/mathrone/backend/util/TokenProviderUtil.java
+++ b/src/main/java/mathrone/backend/util/TokenProviderUtil.java
@@ -39,7 +39,7 @@ public class TokenProviderUtil {
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;       // 1일
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
     public static final String AUTHORIZATION_HEADER = "Authorization";  // http header 종류
-    public static final String BEARER_PREFIX = "Bearer";    // http 인증 type
+//    public static final String BEARER_PREFIX = "Bearer";    // http 인증 type
 
     // key는 HS512 알고리즘을 사용함
     private final Key key;
@@ -147,9 +147,8 @@ public class TokenProviderUtil {
     // Request Header의 토큰 정보 가져오는 메소드
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) &&
-            bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(7);
+        if (StringUtils.hasText(bearerToken)) {
+            return bearerToken;
         }
         return null;
     }


### PR DESCRIPTION
- token 인증 시, Bearer 입력하지 않아도 되도록 수정
- MATHRONE, GOOGLE 하드코딩 문자열을 enum class로 대체