### PR TITLE
Mr-BE-113-AccountID 중복여부 확인 && API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     //google login
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    // DataTime formatter
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.4'
 
 }
 

--- a/src/main/java/mathrone/backend/config/security/CustomUserDetailsService.java
+++ b/src/main/java/mathrone/backend/config/security/CustomUserDetailsService.java
@@ -2,6 +2,8 @@ package mathrone.backend.config.security;
 
 import lombok.RequiredArgsConstructor;
 import mathrone.backend.domain.UserInfo;
+import mathrone.backend.error.exception.ErrorCode;
+import mathrone.backend.error.exception.UserException;
 import mathrone.backend.repository.UserInfoRepository;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -22,7 +24,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
         UserInfo isExist = userRepository.findByAccountId(id).orElseThrow(() ->
-            new UsernameNotFoundException("유저를 찾을 수 없습니다. 아이디를 다시 확인해주세요."));
+            new UserException(ErrorCode.ACCOUNT_NOT_FOUND));
         return User.builder()
             .username(String.valueOf(isExist.getUserId()))
             .password(isExist.getPassword())

--- a/src/main/java/mathrone/backend/controller/UserController.java
+++ b/src/main/java/mathrone/backend/controller/UserController.java
@@ -49,6 +49,12 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping(value = "/check/accountId", headers = {"Content-type=application/json"})
+    public ResponseEntity<Void> validateUserAccountId(@RequestBody String userAccountId) {
+        authService.validateUserAccountId(userAccountId);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping(value = "/signup", headers = {"Content-type=application/json"})
     public ResponseEntity<UserResponseDto> signUp(@RequestBody UserSignUpDto userSignUpDto) {
         return ResponseEntity.ok(authService.signup(userSignUpDto));

--- a/src/main/java/mathrone/backend/controller/UserController.java
+++ b/src/main/java/mathrone/backend/controller/UserController.java
@@ -49,8 +49,8 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(value = "/check/accountId", headers = {"Content-type=application/json"})
-    public ResponseEntity<Void> validateUserAccountId(@RequestBody String userAccountId) {
+    @GetMapping(value = "/check/accountId", headers = {"Content-type=application/json"})
+    public ResponseEntity<Void> validateUserAccountId(@RequestParam String userAccountId) {
         authService.validateUserAccountId(userAccountId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/mathrone/backend/error/ErrorResponse.java
+++ b/src/main/java/mathrone/backend/error/ErrorResponse.java
@@ -1,0 +1,26 @@
+package mathrone.backend.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import mathrone.backend.error.exception.ErrorCode;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int status;
+    private final String message;
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .message(errorCode.getDetail())
+                .build()
+            );
+    }}

--- a/src/main/java/mathrone/backend/error/GlobalExceptionHandler.java
+++ b/src/main/java/mathrone/backend/error/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package mathrone.backend.error;
+
+import static mathrone.backend.error.exception.ErrorCode.SERVER_ERROR;
+
+import lombok.extern.slf4j.Slf4j;
+import mathrone.backend.error.exception.UserException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice // 모든 RestController error handling
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler(value = { UserException.class })
+    public ResponseEntity<ErrorResponse> handleUserException(UserException ue) {
+        log.error("handleUserException throw Exception : {}", ue.getErrorCode());
+        return ErrorResponse.toResponseEntity(ue.getErrorCode());
+    }
+
+    @ExceptionHandler(value = { Exception.class })
+    public ResponseEntity<ErrorResponse> handleException() {
+        log.error("handleUserException throw Exception : {}", SERVER_ERROR.getDetail());
+        return ErrorResponse.toResponseEntity(SERVER_ERROR);
+    }
+
+}

--- a/src/main/java/mathrone/backend/error/exception/ErrorCode.java
+++ b/src/main/java/mathrone/backend/error/exception/ErrorCode.java
@@ -1,0 +1,27 @@
+package mathrone.backend.error.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // user error
+    ACCOUNT_NOT_FOUND(UNAUTHORIZED, "아이디를 찾을 수 없습니다."),
+    ACCOUNT_IS_DUPLICATION(UNAUTHORIZED, "같은 아이디가 이미 존재합니다."),
+
+    // Common
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "예상치 못한 에러가 발생하였습니다.")
+
+    ;
+
+
+    private final HttpStatus httpStatus;
+
+    private final String detail;
+
+}

--- a/src/main/java/mathrone/backend/error/exception/UserException.java
+++ b/src/main/java/mathrone/backend/error/exception/UserException.java
@@ -1,0 +1,10 @@
+package mathrone.backend.error.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/mathrone/backend/repository/UserInfoRepository.java
+++ b/src/main/java/mathrone/backend/repository/UserInfoRepository.java
@@ -17,7 +17,7 @@ public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
     @Query(value = "SELECT COUNT(*) FROM problem_try WHERE user_id=:userId GROUP BY user_id", nativeQuery = true)
     Long getTryByUserID(int userId);
 
-    boolean existsUserInfoByAccountIdAndResType(String accountId, String resType);
+    boolean existsUserInfoByAccountId(String accountId);
 
     boolean existsByEmailAndResType(String email, String resType);
 

--- a/src/main/java/mathrone/backend/service/AuthService.java
+++ b/src/main/java/mathrone/backend/service/AuthService.java
@@ -10,6 +10,8 @@ import mathrone.backend.controller.dto.OauthDTO.GoogleIDToken;
 import mathrone.backend.domain.token.LogoutAccessToken;
 import mathrone.backend.domain.token.RefreshToken;
 import mathrone.backend.domain.UserInfo;
+import mathrone.backend.error.exception.ErrorCode;
+import mathrone.backend.error.exception.UserException;
 import mathrone.backend.repository.UserInfoRepository;
 import mathrone.backend.repository.tokenRepository.LogoutAccessTokenRedisRepository;
 import mathrone.backend.util.TokenProviderUtil;
@@ -39,11 +41,9 @@ public class AuthService {
 
     @Transactional
     public UserResponseDto signup(UserSignUpDto userSignUpDto) {
-        // && type이 MATHRONE인 경우도 같이 검사 -> 같은 id로 여러 sns시스템을 이용할 수 있기 때문
-        if (userinfoRepository.existsUserInfoByAccountIdAndResType(userSignUpDto.getAccountId(),
-            MATHRONE.getTypeName())) {
-            throw new RuntimeException("이미 가입된 유저입니다.");
-        }
+        // user account ID가 존재하는지 검사
+        validateUserAccountId(userSignUpDto.getAccountId());
+
         UserInfo newUser = userSignUpDto.toUser(passwordEncoder,
             MATHRONE.getTypeName()); //MATHRONE user로 가입시켜주기
         return UserResponseDto.of(userinfoRepository.save(newUser));
@@ -231,4 +231,9 @@ public class AuthService {
 
     }
 
+    public void validateUserAccountId(String userAccountId) {
+        if (userinfoRepository.existsUserInfoByAccountId(userAccountId)){
+            throw new UserException(ErrorCode.ACCOUNT_IS_DUPLICATION);
+        }
+    }
 }


### PR DESCRIPTION

@h01010 , @IAGREEBUT 

해당 PR에 대한 task는 다음과 같습니다
- accountId의 중복 여부 확인
- accountId의 중복 여부를 검사하는 API 추가
- Error Response 추가

### Test (Swaager 사용)
### 1.  accountID의 중복여부 확인 테스트

1-1. 회원가입 시 중복된 AccountId를 입력하여 로그인을 진행합니다.
<img width="1428" alt="image" src="https://user-images.githubusercontent.com/33611439/206407297-1ea7a6c0-0137-4d3f-9622-582a3b60c921.png">


1-2. 다음과 같이 같은 아이디가 존재하는 경우, 아이디가 중복되었다는 Error Response를 반환합니다.
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/33611439/206407474-009a8269-ce2f-4c01-af30-680423d3c703.png">


### 2. accountId의 중복 여부를 검사하는 API 테스트
2-1. 위와 동일하게 중복된 AccountId를 입력하여 로그인을 진행합니다.
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/33611439/206408403-b51f3f37-24d1-4caf-8e26-e5eaaade17c9.png">
 

2-2. 다음과 같이 아이디가 중복되었다는 Error Response를 반환합니다.
<img width="1396" alt="image" src="https://user-images.githubusercontent.com/33611439/206408762-68821b65-2b5d-4e81-ab96-cb32af93d051.png">

현재는 RuntimeException에 대한 에러는 서버 에러로 처리하였습니다.

To-do
1. 전체적으로 RuntimeError로 handling한 error의 refactoring을 해야할 것 같습니다..!