### PR TITLE
문제집 즐겨찾기 기능

### DIFF
--- a/src/main/java/mathrone/backend/controller/WorkbookController.java
+++ b/src/main/java/mathrone/backend/controller/WorkbookController.java
@@ -2,6 +2,7 @@ package mathrone.backend.controller;
 
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import io.swagger.annotations.ApiOperation;
@@ -83,6 +84,14 @@ public class WorkbookController {
     public ResponseEntity<List<UserWorkbookDataInterface>> getStarWorkbooks(
         HttpServletRequest request) {
         return ResponseEntity.status(OK).body(workBookService.getStarWorkbook(request));
+    }
+
+    @PostMapping("/star/{workbookId}")
+    @ApiOperation(value = "사용자의 특정 문제집 즐겨찾기 추가 or 제거", notes = "사용자 인증 후, 문제집 즐겨찾기 처리")
+    public ResponseEntity<Object> starWorkbook(
+        HttpServletRequest request, @PathVariable String workbookId) {
+        workBookService.starWorkbook(request, workbookId);
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 
     @GetMapping({"/track/solved", "/track/solved/{workbookId}"})

--- a/src/main/java/mathrone/backend/controller/WorkbookController.java
+++ b/src/main/java/mathrone/backend/controller/WorkbookController.java
@@ -1,6 +1,9 @@
 package mathrone.backend.controller;
 
 
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +18,6 @@ import mathrone.backend.service.WorkBookService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,50 +39,50 @@ public class WorkbookController {
 
     @GetMapping("/list")
     @ApiOperation(value = "workbook 조회", notes = "parameter에 따라 filtering된 workbook 리스트 가져오기")
-    public List<bookItem> bookList(
+    public ResponseEntity<List<bookItem>> bookList(
         @RequestParam(value = "publisher", required = false, defaultValue = "all") String publisher,
         @RequestParam(value = "sortType", required = false, defaultValue = "star") String sortType,
         @RequestParam(value = "category", required = false, defaultValue = "all") String category,
         @RequestParam(value = "pageNum", required = false, defaultValue = "1") Integer pageNum) {
 
         Pageable paging = PageRequest.of(pageNum - 1, 9, Sort.by("workbookId")); //page 0부터임!
-        return workBookService.getBookList(paging, publisher, category, sortType);
+        return ResponseEntity.status(OK).body(workBookService.getBookList(paging, publisher, category, sortType));
     }
 
 
     @GetMapping("/count")
     @ApiOperation(value = "workbook 개수 조회", notes = "parameter에 따라 filtering된 workbook 개수 반환")
-    public Long bookCount(
+    public ResponseEntity<Long> bookCount(
         @RequestParam(value = "publisher", required = false, defaultValue = "all") String publisher,
         @RequestParam(value = "category", required = false, defaultValue = "all") String category) {
         //결과의 수 반환
-        return workBookService.countWorkbook(publisher, category);
+        return ResponseEntity.status(OK).body(workBookService.countWorkbook(publisher, category));
     }
 
 
     @GetMapping("/summary")
     @ApiOperation(value = "문제집 리스트 반환", notes = "publisher와 categories로 group화된 workbook 리스트 반환")
-    public List<bookContent> workbookList() {
-        return workBookService.getWorkbookList();
+    public ResponseEntity<List<bookContent>> workbookList() {
+        return ResponseEntity.status(OK).body(workBookService.getWorkbookList());
     }
 
     @GetMapping("/")
-    public BookDetailDto workbookDetail(
+    public ResponseEntity<BookDetailDto> workbookDetail(
             @RequestParam(value = "id") String bookId) {
-        return workBookService.getWorkbookDetail(bookId);
+        return ResponseEntity.status(OK).body(workBookService.getWorkbookDetail(bookId));
     }
     @GetMapping("/try")
     @ApiOperation(value = "사용자가 시도한 문제집 리스트 반환", notes = "access token가 존재하면 특정 사용자, 존재하지 않으면 모든 사용자가 시도한 문제집 리스트를 반환")
-    public List<UserWorkbookDataInterface> getTriedWorkbooks(
+    public ResponseEntity<List<UserWorkbookDataInterface>> getTriedWorkbooks(
         HttpServletRequest request) {
-        return workBookService.getTriedWorkbook(request);
+        return ResponseEntity.status(OK).body(workBookService.getTriedWorkbook(request));
     }
 
     @GetMapping("/star")
     @ApiOperation(value = "사용자가 즐겨찾는 문제집 리스트 반환", notes = "access token가 존재하면 특정 사용자, 존재하지 않으면 모든 사용자가 즐겨찾는 문제집 리스트를 반환")
-    public List<UserWorkbookDataInterface> getStarWorkbooks(
+    public ResponseEntity<List<UserWorkbookDataInterface>> getStarWorkbooks(
         HttpServletRequest request) {
-        return workBookService.getStarWorkbook(request);
+        return ResponseEntity.status(OK).body(workBookService.getStarWorkbook(request));
     }
 
     @GetMapping({"/track/solved", "/track/solved/{workbookId}"})
@@ -88,7 +90,7 @@ public class WorkbookController {
     public ResponseEntity<List<UserSolvedWorkbookResponseDtoInterface>> trackSolvedWorkbook(
         HttpServletRequest request,
         @PathVariable(value = "workbookId", required = false) Optional<String> workbookId) {
-        return ResponseEntity.ok(workBookService.trackSolvedWorkbook(request, workbookId));
+        return ResponseEntity.status(OK).body(workBookService.trackSolvedWorkbook(request, workbookId));
     }
 
     @PostMapping("/level")
@@ -97,6 +99,6 @@ public class WorkbookController {
         HttpServletRequest request, @RequestBody UserEvaluateLevelRequestDto userEvaluateLevelRequestDto
     ){
         workBookService.evaluateWorkbook(request, userEvaluateLevelRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(CREATED).build();
     }
 }

--- a/src/main/java/mathrone/backend/domain/UserWorkbookRelInfo.java
+++ b/src/main/java/mathrone/backend/domain/UserWorkbookRelInfo.java
@@ -38,18 +38,26 @@ public class UserWorkbookRelInfo {
     private WorkBookInfo workbook;
 
     @NotNull
-    Boolean hide;
+    @Builder.Default()
+    Boolean hide = false;
 
     @NotNull
     @Column(name = "is_vote")
-    Boolean isVote;
+    @Builder.Default()
+    Boolean isVote = false;
 
     @NotNull
     @Column(name = "workbook_star")
-    Boolean workbookStar;
+    @Builder.Default()
+    Boolean workbookStar = false;
 
     @NotNull
     @Column(name = "workbook_try")
-    Boolean workbookTry;
+    @Builder.Default()
+    Boolean workbookTry = false;
+
+    public void updateStar(boolean star){
+        this.workbookStar = star;
+    }
 
 }

--- a/src/main/java/mathrone/backend/repository/UserWorkbookRelRepository.java
+++ b/src/main/java/mathrone/backend/repository/UserWorkbookRelRepository.java
@@ -1,7 +1,9 @@
 package mathrone.backend.repository;
 
 import java.util.List;
+import java.util.Optional;
 import mathrone.backend.controller.dto.UserWorkbookDataInterface;
+import mathrone.backend.domain.UserInfo;
 import mathrone.backend.domain.UserWorkbookRelInfo;
 import mathrone.backend.domain.WorkBookInfo;
 import mathrone.backend.domain.WorkbookRelPK;
@@ -12,6 +14,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserWorkbookRelRepository extends
     JpaRepository<UserWorkbookRelInfo, WorkbookRelPK> {
+    Optional<UserWorkbookRelInfo> findByUserAndWorkbook(UserInfo user, WorkBookInfo workBook);
+
 
     Long countByWorkbookAndWorkbookStar(WorkBookInfo workBookInfo, boolean star);
 

--- a/src/main/java/mathrone/backend/service/WorkBookService.java
+++ b/src/main/java/mathrone/backend/service/WorkBookService.java
@@ -21,6 +21,8 @@ import mathrone.backend.domain.ChapterInfo;
 import mathrone.backend.domain.Problem;
 import mathrone.backend.domain.PubCatPair;
 import mathrone.backend.domain.Tag;
+import mathrone.backend.domain.UserInfo;
+import mathrone.backend.domain.UserWorkbookRelInfo;
 import mathrone.backend.domain.WorkBookInfo;
 import mathrone.backend.domain.WorkbookLevelInfo;
 import mathrone.backend.domain.bookContent;
@@ -29,6 +31,7 @@ import mathrone.backend.error.exception.CustomException;
 import mathrone.backend.error.exception.ErrorCode;
 import mathrone.backend.repository.LevelRepository;
 import mathrone.backend.repository.ProblemRepository;
+import mathrone.backend.repository.UserInfoRepository;
 import mathrone.backend.repository.UserWorkbookRelRepository;
 import mathrone.backend.repository.ChapterRepository;
 import mathrone.backend.repository.TagRepository;
@@ -36,6 +39,7 @@ import mathrone.backend.repository.WorkBookRepository;
 import mathrone.backend.repository.WorkbookLevelRepository;
 import mathrone.backend.util.TokenProviderUtil;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -50,6 +54,7 @@ public class WorkBookService {
     private final TokenProviderUtil tokenProviderUtil;
     private final UserWorkbookRelRepository userWorkbookRelRepository;
     private final WorkbookLevelRepository workbookLevelRepository;
+    private final UserInfoRepository userInfoRepository;
 
 
     public List<WorkBookInfo> findWorkbook(String publisher, String category, Pageable pageable) {
@@ -94,8 +99,8 @@ public class WorkBookService {
     }
 
     // 워크북 상세 페이지에 대한 정보를 불러옴
-    public BookDetailDto getWorkbookDetail(String workbookId){
-        Map< String, List<Chapters>> arrMap = new HashMap<>(); // 그룹 별로 정리하기 위함
+    public BookDetailDto getWorkbookDetail(String workbookId) {
+        Map<String, List<Chapters>> arrMap = new HashMap<>(); // 그룹 별로 정리하기 위함
         List<Chapters> list = new ArrayList<>();
         List<ChapterGroup> chapterGroups = new ArrayList<>();
         List<Tag> tags = new ArrayList<>();
@@ -103,13 +108,13 @@ public class WorkBookService {
         WorkBookInfo workBookInfo = workBookRepository.findByWorkbookId(workbookId);
 
         // 각 그룹별로 챕터 정리
-        if(workBookInfo.getChapterId() != null){
+        if (workBookInfo.getChapterId() != null) {
             for (String s : workBookInfo.getChapterId()) {
                 ChapterInfo chapterInfo = chapterRepository.findByChapterId(s).get();
                 Chapters chapters = Chapters.builder()
-                        .id(chapterInfo.getChapterId())
-                        .name(chapterInfo.getName())
-                        .build();
+                    .id(chapterInfo.getChapterId())
+                    .name(chapterInfo.getName())
+                    .build();
                 if (arrMap.containsKey(chapterInfo.getGroup())) {
                     list = arrMap.get(chapterInfo.getGroup());
                     list.add(chapters);
@@ -122,34 +127,35 @@ public class WorkBookService {
             // 그룹별로 정리한 챕터 정보를 ChapterGroup 리스트 형식에 맞게 변환
             for (String key : arrMap.keySet()) {
                 chapterGroups.add(
-                        ChapterGroup.builder()
-                                .group(key)
-                                .chapters(arrMap.get(key))
-                                .build());
+                    ChapterGroup.builder()
+                        .group(key)
+                        .chapters(arrMap.get(key))
+                        .build());
             }
         }
 
         Long[] tagList = workBookInfo.getTags();
-        if(tagList != null){
-            for(Long i : tagList){
-                if(tagRepository.findById(i).isPresent())
+        if (tagList != null) {
+            for (Long i : tagList) {
+                if (tagRepository.findById(i).isPresent()) {
                     tags.add(tagRepository.findById(i).get());
+                }
             }
         }
         return BookDetailDto.builder()
-                .workbookId(workBookInfo.getWorkbookId())
-                .title(workBookInfo.getTitle())
-                .summary("summary")
-                .publisher(workBookInfo.getPublisher())
-                .category(workBookInfo.getCategory())
-                .thumbnail(workBookInfo.getThumbnail())
-                .content(workBookInfo.getContent())
-                .type(workBookInfo.getType())
-                .year(workBookInfo.getYear())
-                .month(workBookInfo.getMonth())
-                .chapterGroup(chapterGroups)
-                .tags(tags)
-                .build();
+            .workbookId(workBookInfo.getWorkbookId())
+            .title(workBookInfo.getTitle())
+            .summary("summary")
+            .publisher(workBookInfo.getPublisher())
+            .category(workBookInfo.getCategory())
+            .thumbnail(workBookInfo.getThumbnail())
+            .content(workBookInfo.getContent())
+            .type(workBookInfo.getType())
+            .year(workBookInfo.getYear())
+            .month(workBookInfo.getMonth())
+            .chapterGroup(chapterGroups)
+            .tags(tags)
+            .build();
     }
 
     public Long getStar(String workbookId) {
@@ -406,6 +412,40 @@ public class WorkBookService {
             default:
                 throw new CustomException(ErrorCode.INVALID_LEVEL_VALUE);
 
+        }
+    }
+
+    /**
+     * 유저에 대한 workbook의 즐겨찾기 추가 or 삭제
+     *
+     * @param request       http request
+     * @param workbookId    workbook Id
+     */
+    @Transactional
+    public void starWorkbook(HttpServletRequest request, String workbookId) {
+        String accessToken = tokenProviderUtil.resolveToken(request);
+
+        if (!tokenProviderUtil.validateToken(accessToken, request)) {
+            throw (CustomException) request.getAttribute("Exception");
+        }
+
+        int userId = Integer.parseInt(tokenProviderUtil.getAuthentication(accessToken).getName());
+
+        UserInfo user = userInfoRepository.getById(userId);
+        WorkBookInfo workbook = workBookRepository.findById(workbookId).orElseThrow(() ->
+            new CustomException(ErrorCode.NOT_FOUND_WORKBOOK));
+
+        Optional<UserWorkbookRelInfo> byUserAndWorkbook = userWorkbookRelRepository.findByUserAndWorkbook(
+            user, workbook);
+
+        if (byUserAndWorkbook.isEmpty()){
+            userWorkbookRelRepository.save(UserWorkbookRelInfo.builder()
+                .workbook(workbook)
+                .user(user)
+                .workbookStar(true).build());
+        } else {
+            UserWorkbookRelInfo userWorkbookRelInfo = byUserAndWorkbook.get();
+            userWorkbookRelInfo.updateStar(!userWorkbookRelInfo.getWorkbookStar());
         }
     }
 }


### PR DESCRIPTION
## 진행 Task

- 유저가 특정 문제집의 즐겨찾기 추가 or 제거

### Test 과정
**※ (tester/tester) 계정을 통해 로그인 후 반환되는 access token을 가지고 test 진행 ※**

<img width="1402" alt="image" src="https://github.com/2021-Techeer-teamC/MATHRONE_Backend/assets/33611439/9a85ba44-2d82-430f-9a3f-c0f22eb5ec8b">

#### [유저의 문제집 즐겨찾기 API test]
**1. 임의의 workbookId 를 입력하여 test 진행**
<img width="1438" alt="image" src="https://github.com/2021-Techeer-teamC/MATHRONE_Backend/assets/33611439/d52663f6-5221-464b-9908-b1f78fdccf97">

2. **user_workbook_rel table에서 즐겨찾기 여부 확인** (기존 데이터의 workbookStar column값이 true인 경우, test시 즐겨찾기 삭제를 진행, 즉 workbookStar column값이 false로 수정됨)
<img width="712" alt="image" src="https://github.com/2021-Techeer-teamC/MATHRONE_Backend/assets/33611439/e45d20d3-8cd5-44c7-9f8e-89a1d30f7d42">

한 번 더 실행 시 workbookStar값이 false가 되는 것을 볼 수 있음.

<img width="704" alt="image" src="https://github.com/2021-Techeer-teamC/MATHRONE_Backend/assets/33611439/f25e0e07-fbb4-4aa8-bee3-a0977289a710">

